### PR TITLE
download.py: no longer downloads the entire video, only necessary segment for Kinetics. 

### DIFF
--- a/Crawler/Kinetics/download.py
+++ b/Crawler/Kinetics/download.py
@@ -87,7 +87,7 @@ def download_clip(video_identifier, output_filename,
             direct_download_url = subprocess.check_output(command,
                                                           shell=True,
                                                           stderr=subprocess.STDOUT)
-            direct_download_url = direct_download_url.strip()
+            direct_download_url = direct_download_url.strip().decode('utf-8')
          except subprocess.CalledProcessError as err:
             attempts += 1
             if attempts == num_attempts:

--- a/Crawler/Kinetics/download.py
+++ b/Crawler/Kinetics/download.py
@@ -78,10 +78,11 @@ def download_clip(video_identifier, output_filename,
     # Construct command line for getting the direct video link.
     command = ['youtube-dl',
                '--quiet', '--no-warnings',
-               '-f', 'mp4',
+               '-f', '18', # 640x360 h264 encoded video
                '--get-url',
                '"%s"' % (url_base + video_identifier)]
     command = ' '.join(command)
+    direct_download_url = None
     attempts = 0
     while True:
          try:
@@ -94,7 +95,9 @@ def download_clip(video_identifier, output_filename,
             if attempts == num_attempts:
                 return status, err.output
             else:
-                break
+                continue
+
+         break
 
     # Construct command to trim the videos (ffmpeg required).
     command = ['ffmpeg',

--- a/Crawler/Kinetics/download.py
+++ b/Crawler/Kinetics/download.py
@@ -1,3 +1,4 @@
+
 import argparse
 import glob
 import json
@@ -92,15 +93,16 @@ def download_clip(video_identifier, output_filename,
             attempts += 1
             if attempts == num_attempts:
                 return status, err.output
-        else:
-            break
+            else:
+                break
 
     # Construct command to trim the videos (ffmpeg required).
     command = ['ffmpeg',
                '-ss', str(start_time),
                '-t', str(end_time - start_time),
                '-i', "'%s'" % direct_download_url,
-               '-c:v', 'copy', '-c:a', 'copy',
+               '-c:v', 'libx264', '-preset', 'veryfast',
+               '-c:a', 'aac',
                '-threads', '1',
                '-loglevel', 'panic',
                '"%s"' % output_filename]

--- a/Crawler/Kinetics/download.py
+++ b/Crawler/Kinetics/download.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 
 import argparse
 import glob
@@ -104,7 +105,7 @@ def download_clip(video_identifier, output_filename,
                '-ss', str(start_time),
                '-t', str(end_time - start_time),
                '-i', "'%s'" % direct_download_url,
-               '-c:v', 'libx264', '-preset', 'veryfast',
+               '-c:v', 'libx264', '-preset', 'ultrafast',
                '-c:a', 'aac',
                '-threads', '1',
                '-loglevel', 'panic',


### PR DESCRIPTION
`Crawler/Kinetics/download.py` downloads the entire video from youtube (which can be tens of minutes long) then uses ffmpeg to extract the short clip specified in the Kinetics dataset (the clips are ~10 seconds on average). I have changed the code so that it only downloads the necessary segment of video from youtube, saving A TON of time downloading video. 