### PR TITLE
Update AVA eval code to support AVA-Kinetics

### DIFF
--- a/Evaluation/get_ava_performance.py
+++ b/Evaluation/get_ava_performance.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import argparse
 from collections import defaultdict
 import csv
+import decimal
 import heapq
 import logging
 import pprint
@@ -34,7 +35,7 @@ def print_time(message, start):
 
 def make_image_key(video_id, timestamp):
   """Returns a unique identifier for a video id & timestamp."""
-  return "%s,%04d" % (video_id, int(timestamp))
+  return "%s,%.6f" % (video_id, decimal.Decimal(timestamp))
 
 
 def read_csv(csv_file, class_whitelist=None, capacity=0):

--- a/Evaluation/get_ava_performance.py
+++ b/Evaluation/get_ava_performance.py
@@ -71,6 +71,9 @@ def read_csv(csv_file, class_whitelist=None, capacity=0):
     assert len(row) in [2, 7, 8], "Wrong number of columns: " + row
     image_key = make_image_key(row[0], row[1])
     all_keys.add(image_key)
+    # Rows with 2 tokens (videoid,timestatmp) indicates images with no detected
+    # / ground truth actions boxes. Add them to all_keys, so we can score
+    # appropriately, but otherwise skip the box creation steps.
     if len(row) == 2:
       continue
     x1, y1, x2, y2 = [float(n) for n in row[2:6]]

--- a/Evaluation/get_ava_performance.py
+++ b/Evaluation/get_ava_performance.py
@@ -7,7 +7,6 @@ Example usage:
 python -O get_ava_performance.py \
   -l ava/ava_action_list_v2.1_for_activitynet_2018.pbtxt.txt \
   -g ava_val_v2.1.csv \
-  -e ava_val_excluded_timestamps_v2.1.csv \
   -d your_results.csv
 """
 
@@ -47,8 +46,8 @@ def read_csv(csv_file, class_whitelist=None, capacity=0):
     csv_file: A file object.
     class_whitelist: If provided, boxes corresponding to (integer) class labels
       not in this set are skipped.
-    capacity: Maximum number of labeled boxes allowed for each example.
-      Default is 0 where there is no limit.
+    capacity: Maximum number of labeled boxes allowed for each example. Default
+      is 0 where there is no limit.
 
   Returns:
     boxes: A dictionary mapping each unique image key (string) to a list of
@@ -58,16 +57,21 @@ def read_csv(csv_file, class_whitelist=None, capacity=0):
     scores: A dictionary mapping each unique image key (string) to a list of
       score values lables, matching the corresponding label in `labels`. If
       scores are not provided in the csv, then they will default to 1.0.
+    all_keys: A set of all image keys found in the csv file.
   """
   start = time.time()
   entries = defaultdict(list)
   boxes = defaultdict(list)
   labels = defaultdict(list)
   scores = defaultdict(list)
+  all_keys = set()
   reader = csv.reader(csv_file)
   for row in reader:
-    assert len(row) in [7, 8], "Wrong number of columns: " + row
+    assert len(row) in [2, 7, 8], "Wrong number of columns: " + row
     image_key = make_image_key(row[0], row[1])
+    all_keys.add(image_key)
+    if len(row) == 2:
+      continue
     x1, y1, x2, y2 = [float(n) for n in row[2:6]]
     action_id = int(row[6])
     if class_whitelist and action_id not in class_whitelist:
@@ -76,11 +80,9 @@ def read_csv(csv_file, class_whitelist=None, capacity=0):
     if len(row) == 8:
       score = float(row[7])
     if capacity < 1 or len(entries[image_key]) < capacity:
-      heapq.heappush(entries[image_key],
-                     (score, action_id, y1, x1, y2, x2))
+      heapq.heappush(entries[image_key], (score, action_id, y1, x1, y2, x2))
     elif score > entries[image_key][0][0]:
-      heapq.heapreplace(entries[image_key],
-                        (score, action_id, y1, x1, y2, x2))
+      heapq.heapreplace(entries[image_key], (score, action_id, y1, x1, y2, x2))
   for image_key in entries:
     # Evaluation API assumes boxes with descending scores
     entry = sorted(entries[image_key], key=lambda tup: -tup[0])
@@ -90,26 +92,7 @@ def read_csv(csv_file, class_whitelist=None, capacity=0):
       labels[image_key].append(action_id)
       scores[image_key].append(score)
   print_time("read file " + csv_file.name, start)
-  return boxes, labels, scores
-
-
-def read_exclusions(exclusions_file):
-  """Reads a CSV file of excluded timestamps.
-
-  Args:
-    exclusions_file: A file object containing a csv of video-id,timestamp.
-
-  Returns:
-    A set of strings containing excluded image keys, e.g. "aaaaaaaaaaa,0904",
-    or an empty set if exclusions file is None.
-  """
-  excluded = set()
-  if exclusions_file:
-    reader = csv.reader(exclusions_file)
-    for row in reader:
-      assert len(row) == 2, "Expected only 2 columns, got: " + row
-      excluded.add(make_image_key(row[0], row[1]))
-  return excluded
+  return boxes, labels, scores, all_keys
 
 
 def read_labelmap(labelmap_file):
@@ -137,31 +120,25 @@ def read_labelmap(labelmap_file):
   return labelmap, class_ids
 
 
-def run_evaluation(labelmap, groundtruth, detections, exclusions):
+def run_evaluation(labelmap, groundtruth, detections):
   """Runs evaluations given input files.
 
   Args:
     labelmap: file object containing map of labels to consider, in pbtxt format
     groundtruth: file object
     detections: file object
-    exclusions: file object or None.
   """
   categories, class_whitelist = read_labelmap(labelmap)
   logging.info("CATEGORIES (%d):\n%s", len(categories),
                pprint.pformat(categories, indent=2))
-  excluded_keys = read_exclusions(exclusions)
 
   pascal_evaluator = object_detection_evaluation.PascalDetectionEvaluator(
       categories)
 
   # Reads the ground truth data.
-  boxes, labels, _ = read_csv(groundtruth, class_whitelist, 0)
+  boxes, labels, _, included_keys = read_csv(groundtruth, class_whitelist, 0)
   start = time.time()
   for image_key in boxes:
-    if image_key in excluded_keys:
-      logging.info(("Found excluded timestamp in ground truth: %s. "
-                    "It will be ignored."), image_key)
-      continue
     pascal_evaluator.add_single_ground_truth_image_info(
         image_key, {
             standard_fields.InputDataFields.groundtruth_boxes:
@@ -174,12 +151,12 @@ def run_evaluation(labelmap, groundtruth, detections, exclusions):
   print_time("convert groundtruth", start)
 
   # Reads detections data.
-  boxes, labels, scores = read_csv(detections, class_whitelist, 50)
+  boxes, labels, scores, _ = read_csv(detections, class_whitelist, 50)
   start = time.time()
   for image_key in boxes:
-    if image_key in excluded_keys:
-      logging.info(("Found excluded timestamp in detections: %s. "
-                    "It will be ignored."), image_key)
+    if image_key not in included_keys:
+      logging.info(("Found detections for image %s which is not part of the "
+                    "the ground truth. They will be ignored."), image_key)
       continue
     pascal_evaluator.add_single_detected_image_info(
         image_key, {
@@ -224,13 +201,6 @@ def parse_arguments():
       help="CSV file containing inferred action detections.",
       type=argparse.FileType("r"),
       required=True)
-  parser.add_argument(
-      "-e",
-      "--exclusions",
-      help=("Optional CSV file containing videoid,timestamp pairs to exclude "
-            "from evaluation."),
-      type=argparse.FileType("r"),
-      required=False)
   return parser.parse_args()
 
 


### PR DESCRIPTION
Updates the code to handle timestamps with microsecond precision, as floating point tnumbers.

Also simplifies the handling of negative keyframes (those without any actions), by including them in the ground truth csv as rows with only two tokens: videoid,timestamp. This allows us to eliminate the --exclusions command-line argument entirely.